### PR TITLE
[feature] Replace em icon with home icon

### DIFF
--- a/src/components/HomeLink.js
+++ b/src/components/HomeLink.js
@@ -1,10 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { store } from '../store.js'
-import logo from '../images/logo-black-inline.png'
-import logoDark from '../images/logo-white-inline.png'
-import logoInline from '../images/logo-black-inline.png'
-import logoDarkInline from '../images/logo-white-inline.png'
 
 // components
 import { Helper } from './Helper.js'
@@ -31,8 +27,21 @@ export const HomeLink = connect(({ settings, focus, showHelper }) => ({
       else {
         home()
       }
-    }}><span role='img' arial-label='home'><img className='logo' src={inline ? (dark ? logoDarkInline : logoInline) : (dark ? logoDark : logo)} alt='em' /></span></a>
-    {showHelper === 'home' ? <Helper id='home' title='Tap the "em" icon to return to the home context' arrow='arrow arrow-top arrow-topleft' /> : null}
+    }}>
+      <span role='img' arial-label='home'>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+          className='logo'
+          fill={dark ? '#FFF' : '#000'}
+          alt='em'>
+          <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+          <path d="M0 0h24v24H0z" fill="none" />
+        </svg>
+      </span>
+    </a>
+    {showHelper === 'home'
+      ? <Helper id='home' title='Tap the "em" icon to return to the home context' arrow='arrow arrow-top arrow-topleft' />
+      : null
+    }
   </span>
 )
 

--- a/src/images/icon-home.svg
+++ b/src/images/icon-home.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+  <path d="M0 0h24v24H0z" fill="none" />
+</svg>


### PR DESCRIPTION
Replaced the EM logo on HomeLink component with Material UI's Home/House icon.

I placed the SVG inside the HomeLink because the project is using an old react-script version that does not allow `import {ReactComponent as Icon} from '../path/icon.svg'`

Closes #50 